### PR TITLE
[bugfix] introduce new handler Restart sensu services

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,9 +4,4 @@
   service:
     name: "{{ sensu_api_service }}"
     state: restarted
-
-- name: Restart sensu services
-  service:
-    name: "{{ sensu_api_service }}"
-    state: restarted
   listen: "Restart sensu services"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,9 @@
   service:
     name: "{{ sensu_api_service }}"
     state: restarted
+
+- name: Restart sensu services
+  service:
+    name: "{{ sensu_api_service }}"
+    state: restarted
+  listen: "Restart sensu services"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Tomoyuki Sakurai
-  description: Configures something
+  description: Configures sensu-api
   company: Reallyenglish
   license: BSD
   min_ansible_version: 2.0
@@ -23,4 +23,3 @@ galaxy_info:
     - sensu
     - monitoring
 dependencies:
-  - { role: reallyenglish.freebsd-repos }

--- a/tasks/install-FreeBSD.yml
+++ b/tasks/install-FreeBSD.yml
@@ -9,3 +9,4 @@
   patch:
     src: files/patches/FreeBSD_rcd_api.patch
     dest: /usr/local/etc/rc.d/sensu-api
+  notify: Restart sensu_api_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,14 +25,14 @@
     src: config.json.j2
     dest: "{{ sensu_api_config_file }}"
     validate: "python -c 'import sys; import json; json.loads(open(sys.argv[1]).read())' %s"
-  notify: Restart sensu_api_service
+  notify: Restart sensu services
 
 - name: Create json files
   template:
     src: json.j2
     dest: "{{ sensu_api_conf_d_dir }}/{{ item }}.json"
     validate: "python -c 'import sys; import json; json.loads(open(sys.argv[1]).read())' %s"
-  notify: Restart sensu_api_service
+  notify: Restart sensu services
   with_items: "{{ sensu_api_config_fragments }}"
 
 

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -1,5 +1,6 @@
 - hosts: localhost
   roles:
+    - reallyenglish.freebsd-repos
     - ansible-role-sensu-api
   vars:
     freebsd_repos:


### PR DESCRIPTION
fixes #3

the handler is intended to be called when all sensu services should be
restarted, such as when one of configuration files changes.

also, restart the service when the rc.d script is patched.

requires ansible 2.2